### PR TITLE
Add last 10 games to player props

### DIFF
--- a/PLAYER_PROPS_ROADMAP.md
+++ b/PLAYER_PROPS_ROADMAP.md
@@ -7,8 +7,8 @@ Enhancement roadmap for NFL Player Props prediction system. Prioritized by impac
 
 ## 🔥 High Priority Improvements
 
-### ~~1. Opponent Defense Rankings~~ ✅
-**Impact**: High | **Complexity**: Medium | **Timeline**: 1-2 days | **Status**: Completed
+### 1. Opponent Defense Rankings
+**Impact**: High | **Complexity**: Medium | **Timeline**: 1-2 days
 
 Add defensive rankings to improve prediction accuracy by accounting for matchup difficulty.
 

--- a/pages/2_🎯_Player_Props.py
+++ b/pages/2_🎯_Player_Props.py
@@ -320,6 +320,7 @@ def main():
                 )
                 display_df['Last 3 Avg'] = display_df['avg_L3'].apply(lambda x: f"{x:.1f}")
                 display_df['Last 5 Avg'] = display_df['avg_L5'].apply(lambda x: f"{x:.1f}")
+                display_df['Last 10 Avg'] = display_df['avg_L10'].apply(lambda x: f"{x:.1f}")
                 display_df['Defense Rank'] = display_df['opponent_def_rank'].apply(
                     lambda x: f"#{int(x)}/32" + (" 🛡️" if x <= 8 else (" ⚠️" if x >= 24 else ""))
                 )
@@ -327,7 +328,7 @@ def main():
                 # Select columns to show
                 show_cols = [
                     'display_name', 'position', 'team', 'opponent', 'Defense Rank', 'prop_type', 
-                    'Recommendation', 'Confidence', 'Tier', 'Last 3 Avg', 'Last 5 Avg'
+                    'Recommendation', 'Confidence', 'Tier', 'Last 3 Avg', 'Last 5 Avg', 'Last 10 Avg'
                 ]
                 
                 st.dataframe(


### PR DESCRIPTION
This pull request introduces a new "Last 10 Avg" player statistic to the player props prediction system and updates the enhancement roadmap to reflect ongoing work on opponent defense rankings. These changes improve the depth of player performance data and clarify the current development status of key features.

**Player statistics enhancements:**

* Added a new column, `Last 10 Avg`, to the displayed player statistics by formatting the `avg_L10` value and including it in both the dataframe and the visible columns.

**Roadmap update:**

* Updated the enhancement roadmap (`PLAYER_PROPS_ROADMAP.md`) to indicate that the "Opponent Defense Rankings" feature is no longer marked as completed, clarifying its current status in the development process.