### PR TITLE
Added keep alive

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,0 +1,70 @@
+name: Keep Streamlit App Alive
+
+# This workflow pings the Streamlit app to prevent it from going to sleep
+# due to inactivity on Streamlit Community Cloud.
+#
+# Features:
+# - Runs twice daily with configurable schedule
+# - Adds random 0-20 minute delay to vary timing (looks more natural in logs)
+# - Tolerates failures without breaking the workflow
+#
+# To use in another repository:
+# 1. Copy this file to .github/workflows/
+# 2. Update the STREAMLIT_APP_URL below with your app's URL
+# 3. Adjust the schedule if needed (currently runs twice daily)
+# 4. Adjust DELAY calculation to change random window (currently 0-20 min)
+
+on:
+  schedule:
+    # Run twice daily: 9 AM and 9 PM UTC (4 AM and 4 PM ET)
+    # Adjust times based on your primary user timezone
+    - cron: '0 9,21 * * *'
+  
+  workflow_dispatch:  # Allow manual trigger for testing
+
+env:
+  # UPDATE THIS: Replace with your Streamlit app URL
+  STREAMLIT_APP_URL: 'https://nfl-predictions.streamlit.app/'
+
+jobs:
+  ping-app:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25  # Allow for 20-minute random delay + ping time
+
+    steps:
+      - name: Random delay (0-20 minutes)
+        run: |
+          # Add random delay to vary timing and make logs look more natural
+          DELAY=$((RANDOM % 1200))  # 0-1200 seconds (0-20 minutes)
+          echo "⏳ Waiting ${DELAY} seconds before ping..."
+          sleep $DELAY
+      
+      - name: Ping Streamlit App
+        run: |
+          echo "🔔 Pinging Streamlit app at: ${{ env.STREAMLIT_APP_URL }}"
+          echo "   Time: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+          
+          # Make HTTP request with timeout
+          RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
+            --max-time 30 \
+            --retry 2 \
+            --retry-delay 5 \
+            "${{ env.STREAMLIT_APP_URL }}")
+          
+          echo "   Response code: $RESPONSE"
+          
+          # Check if request was successful (2xx or 3xx status codes)
+          if [ "$RESPONSE" -ge 200 ] && [ "$RESPONSE" -lt 400 ]; then
+            echo "✅ App is alive and responding!"
+            exit 0
+          else
+            echo "⚠️  App returned status code: $RESPONSE"
+            echo "   This might be temporary - will retry on next schedule"
+            exit 0  # Don't fail the workflow, just log the issue
+          fi
+
+      - name: Log completion
+        if: always()
+        run: |
+          echo "📊 Keep-alive ping completed"
+          echo "   Next scheduled run: Check the Actions tab for schedule"

--- a/.github/workflows/rss_test.yml
+++ b/.github/workflows/rss_test.yml
@@ -1,0 +1,54 @@
+name: RSS Feed Test
+
+on:
+  push:
+    branches: [ main, feature/** ]
+  workflow_dispatch: {}
+
+jobs:
+  rss-test:
+    runs-on: ubuntu-latest
+    env:
+      # Provide a repository secret named ALERTS_SITE_URL to validate links
+      # Example: https://your-deployed-app.example.com/
+      ALERTS_SITE_URL: ${{ secrets.ALERTS_SITE_URL }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          lfs: false  # Skip LFS to avoid bandwidth limits
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Install minimal dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pandas requests
+
+      - name: Confirm ALERTS_SITE_URL presence
+        run: |
+          python - <<'PY'
+          import os
+          v = os.environ.get('ALERTS_SITE_URL')
+          if v:
+              print('ALERTS_SITE_URL is set (secret present).')
+          else:
+              print('ALERTS_SITE_URL is not set — the test will validate against localhost by default.')
+          PY
+
+      - name: Generate RSS feed
+        run: |
+          python scripts/generate_rss.py
+
+      - name: Run RSS link resolution test
+        run: |
+          python tests/test_rss_links.py
+
+      - name: Upload generated RSS as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: alerts-feed
+          path: data_files/alerts_feed.xml

--- a/.github/workflows/update-schedule.yml
+++ b/.github/workflows/update-schedule.yml
@@ -1,0 +1,48 @@
+name: Update NFL Schedule
+
+on:
+  schedule:
+    # Run daily at 06:00 UTC
+    - cron: '0 6 * * *'
+  workflow_dispatch: {}
+  push:
+    branches:
+      - main
+
+jobs:
+  update-schedule:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          lfs: false  # Skip LFS to avoid bandwidth limits
+          persist-credentials: true
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+      - name: Run schedule updater
+        run: python update_schedule.py
+
+      - name: Commit and push updated schedule (if any)
+        env:
+          GIT_AUTHOR_NAME: github-actions[bot]
+          GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com
+        run: |
+          git config user.name "$GIT_AUTHOR_NAME"
+          git config user.email "$GIT_AUTHOR_EMAIL"
+          git add data_files/nfl_schedule_*.csv || true
+          if ! git diff --staged --quiet; then
+            git commit -m "Automated schedule update"
+            git push
+          else
+            echo "No schedule changes to commit"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,11 @@
 /Include/*
 /pyvenv.cfg
 /share/*
-.github/*
-!.github/copilot-instructions.md
-!.github/workflows/send_predictions_schedule.yml
+# .github/*
+# !.github/copilot-instructions.md
+# !.github/workflows/send_predictions_schedule.yml
+.github/workflows/rss-test.yml
+# !.github/workflows/update_schedule.yml
 .venv/*
 venv/
 


### PR DESCRIPTION
This pull request adds three new GitHub Actions workflows to automate key tasks for the project. These workflows help keep the Streamlit app active, automate NFL schedule updates, and test RSS feed generation and link resolution. The main changes are grouped below:

**New automation workflows:**

* Added `.github/workflows/keep-alive.yml` to periodically ping the Streamlit app, preventing it from going to sleep due to inactivity. This workflow runs twice daily, includes a randomized delay, and is tolerant of failures.
* Added `.github/workflows/update-schedule.yml` to automatically update the NFL schedule daily at 06:00 UTC. The workflow installs dependencies, runs the schedule updater script, and commits any changes to the schedule files.

**Testing and validation:**

* Added `.github/workflows/rss_test.yml` to test RSS feed generation and validate RSS links on every push to `main` and `feature/**` branches, as well as on manual trigger. The workflow checks for the presence of a site URL secret, generates the RSS feed, runs link resolution tests, and uploads the generated feed as an artifact.